### PR TITLE
Removing new domain tag from genomics and CardX use cases

### DIFF
--- a/content/uses/discovery.json
+++ b/content/uses/discovery.json
@@ -3,19 +3,19 @@
     "title": "CardX Hypertension Management",
     "description": "Design and build an integrated standard that enables interoperable, scalable, and accessible hypertension management, both at home and in the clinic, so that blood pressure data can easily be shared among home blood pressure measurement devices, patient data managers, and health systems. ",
     "url": "https://confluence.hl7.org/display/COD/CardX+-+Hypertension+Management",
-    "newDomain": true
+    "newDomain": false
   },
   {
     "title": "Genomics Data Exchange",
     "description": "Design and build an integrated standard that enables interoperable, scalable, and accessible genomics data that can easily be shared among laboratories, EHR Systems, and/or genomics repositories. ",
     "url": "https://confluence.hl7.org/display/COD/GenomeX+-+Genomics+Data+Exchange",
-    "newDomain": true
+    "newDomain": false
   },
   {
     "title": "Genomics Operations",
     "description": "Enable access to complex genomic data through APIs so that developers can more easily develop and populate data for a range of genomic applications. ",
     "url": "https://confluence.hl7.org/display/COD/GenomeX+-+Genomics+Operations",
-    "newDomain": true
+    "newDomain": false
   },
   {
     "title": "Quality Measures",


### PR DESCRIPTION
Setting the new domain flag to false for Genomics and CardX as requested.